### PR TITLE
Bug: m is none (in line 180) fix

### DIFF
--- a/lib/whitespace_tokenize.py
+++ b/lib/whitespace_tokenize.py
@@ -175,7 +175,7 @@ def tokenize(text,abbr=None,add_sents=False):
 							output += m.group(1) + "\n"
 
 					while re.search(r'(.)(--)$',subunit) is not None:
-						m = re.match(r'(.)(--)$',subunit)
+						m = re.search(r'(.)(--)$',subunit)
 						subunit = re.sub(r'(.)(--)$',r'\1',subunit)
 						suffix = m.group(2) + "\n" + suffix
 


### PR DESCRIPTION
Bug: m is none (in line 180) due to the use of search and then match.
Search match a the expression in the entire string, match in the beginning of the string.

This seems to be the desired behavior. But need confirmation.