### PR TITLE
Update timing.py

### DIFF
--- a/hebpipe/lib/timing.py
+++ b/hebpipe/lib/timing.py
@@ -1,7 +1,10 @@
 import atexit
 import sys
-from time import clock
 from functools import reduce
+try:
+    from time import clock
+except ImportError:
+    from time import process_time as clock
 
 def secondsToStr(t):
     return "%d:%02d:%02d.%03d" % \


### PR DESCRIPTION
time.clock() deprecated since python 3.3, and removed by 3.8